### PR TITLE
Add a release workflow.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,3 +1,4 @@
+# When a GitHub release is created, this workflow will build and publish the executable.
 name: Release
 
 concurrency:
@@ -7,8 +8,7 @@ concurrency:
 'on':
   release:
     types:
-      - created
-  pull_request: null # TODO remove this.
+    - created
 
 jobs:
   build:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,46 @@
+# apk add build-base openssl-dev openssl-libs-static
+# OPENSSL_STATIC=1
+# OPENSSL_LIB_DIR=/usr/lib
+# OPENSSL_INCLUDE_DIR=/usr/include/openssl
+# RUSTFLAGS='-C target-feature=+crt-static'
+# cargo build --release --target x86_64-unknown-linux-musl
+# Grab /src/target/x86_64-unknown-linux-musl/release/proa
+
+name: Release
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+'on':
+  release:
+    types:
+      - created
+  pull_request: null # TODO remove this.
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        rust_target:
+        - x86_64-unknown-linux-gnu
+    steps:
+    - run: apt-get update && apt-get install build-essential libssl-dev
+    - uses: actions/checkout@v3
+    - uses: IronCoreLabs/rust-toolchain@v1
+      with:
+        targets: ${{ matrix.rust_target }}
+    - uses: Swatinem/rust-cache@v2
+    - run: cargo build --release --target=${{ matrix.rust_target }}
+      env:
+        OPENSSL_STATIC: "1"
+        OPENSSL_LIB_DIR: /usr/lib
+        OPENSSL_INCLUDE_DIR: /usr/include/openssl
+        RUSTFLAGS: "-C target-feature=+crt-static"
+    - name: Upload release asset
+      run: |
+        mv target/${{ matrix.rust_target }}/release/proa proa-${{ matrix.rust_target }}
+        gh release upload ${{ github.event.release.tag_name }} proa-${{ matrix.rust_target }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,11 +1,3 @@
-# apk add build-base openssl-dev openssl-libs-static
-# OPENSSL_STATIC=1
-# OPENSSL_LIB_DIR=/usr/lib
-# OPENSSL_INCLUDE_DIR=/usr/include/openssl
-# RUSTFLAGS='-C target-feature=+crt-static'
-# cargo build --release --target x86_64-unknown-linux-musl
-# Grab /src/target/x86_64-unknown-linux-musl/release/proa
-
 name: Release
 
 concurrency:
@@ -35,7 +27,7 @@ jobs:
     - run: cargo build --release --target=${{ matrix.rust_target }}
       env:
         OPENSSL_STATIC: "1"
-        OPENSSL_LIB_DIR: /usr/lib
+        OPENSSL_LIB_DIR: /usr/lib/x86_64-linux-gnu
         OPENSSL_INCLUDE_DIR: /usr/include/openssl
         RUSTFLAGS: "-C target-feature=+crt-static"
     - name: Upload release asset

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,7 @@ jobs:
         rust_target:
         - x86_64-unknown-linux-gnu
     steps:
-    - run: apt-get update && apt-get install build-essential libssl-dev
+    - run: sudo apt-get update && sudo apt-get install build-essential libssl-dev
     - uses: actions/checkout@v3
     - uses: IronCoreLabs/rust-toolchain@v1
       with:

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,6 @@
+1. Increment the version number in `Cargo.toml`.
+1. `cargo fetch` to update `Cargo.lock`.
+1. Commit and push.
+1. Merge the PR.
+1. `cargo publish`
+1. Create a release on GitHub to trigger the `release.yaml` workflow.


### PR DESCRIPTION
This will produce a statically-linked executable and upload it to GitHub releases.